### PR TITLE
 Update CSS and add league group ranking component

### DIFF
--- a/front/app/public/assets/css/main.min.css
+++ b/front/app/public/assets/css/main.min.css
@@ -6767,8 +6767,8 @@ div:not(.d-hero-bottom) + .d-tournaments:before {
 .d-info .b-accordion .accordion .accordion-item .accordion-body {
   padding-left: 0;
   padding-right: 0;
-  padding-top: 90px;
-  padding-bottom: 90px;
+  padding-top: 45px;
+  padding-bottom: 45px;
 }
 @media (max-width: 768px) {
   .d-info .b-accordion .accordion .accordion-item .accordion-body {

--- a/front/app/src/components/leagueGroupsQ.astro
+++ b/front/app/src/components/leagueGroupsQ.astro
@@ -1,5 +1,4 @@
 ---
-import Versus from "./versus.astro";
 import Arrow from "public/assets/img/icons/arrow-accordion.svg";
 const { tID } = Astro.props;
 const round = "gq";
@@ -23,7 +22,7 @@ const globalQ = await fetch(
           aria-expanded="false"
           aria-controls={`ppanelsStayOpen-collapse-0-${round}`}
         >
-          "Clasificacion Global"
+          Clasificacion Global
           <img
             decoding="async"
             loading="lazy"
@@ -41,35 +40,48 @@ const globalQ = await fetch(
         style=""
       >
         <div class="accordion-body">
-          <div class="row">
-            <div
-              class="col-lg-12 b-player-info-points player-item-f aos-init aos-animate"
-              data-aos="fade-up"
-            >
-              <div class="info-tournament-points">
-                {globalQ?.couples?.map((item: any) => (
-                  <div>
-                    <p class="group_couple mb-4">{item.couple_names}</p>
-                    <div class="row d-flex justify-content-center">
-                      <div class="col-3 text-center">
-                        <p>Sets</p>
-                        <p class="points">{item.sets_total}</p>
-                      </div>
-                      <div class="col-3 text-center">
-                        <p>Games</p>
-                        <p class="points">{item.total_games}</p>
-                      </div>
-                      <div class="col-3 text-center">
-                        <p>Games+</p>
-                        <p class="points">{item.games_positive}</p>
-                      </div>
-                      <div class="col-3 text-center">
-                        <p>Ganados</p>
-                        <p class="points">{item.wins}</p>
+          <div
+            class="col-lg-12 col-sm-12 col-md-12 b-list-ranking aos-init aos-animate"
+            data-aos="fade-up"
+          >
+            <div class="row">
+              <div
+                class="col-lg-12 b-player-info-points player-item-f aos-init aos-animate"
+                data-aos="fade-up"
+              >
+                <div class="info-tournament-points">
+                  {globalQ?.couples?.map((item: any, index) => (
+                    <div>
+                      <p class="group_couple mb-4">{item.couple_names}</p>
+                      <div class="row d-flex justify-content-center">
+                        <div class="col-2 text-center">
+                          <p>&nbsp;</p>
+                          <p class="points">{index + 1}</p>
+                        </div>
+                        <div class="col-2 text-center">
+                          <p>Grupo</p>
+                          <p class="points">{item.group_id + item.id}</p>
+                        </div>
+                        <div class="col-2 text-center">
+                          <p>Sets</p>
+                          <p class="points">{item.sets_total}</p>
+                        </div>
+                        <div class="col-2 text-center">
+                          <p>Games</p>
+                          <p class="points">{item.total_games}</p>
+                        </div>
+                        <div class="col-2 text-center">
+                          <p>Games+</p>
+                          <p class="points">{item.games_positive}</p>
+                        </div>
+                        <div class="col-2 text-center">
+                          <p>Ganados</p>
+                          <p class="points">{item.wins}</p>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                ))}
+                  ))}
+                </div>
               </div>
             </div>
           </div>

--- a/front/app/src/pages/index.astro
+++ b/front/app/src/pages/index.astro
@@ -43,7 +43,7 @@ function getDateDay(dateStr: string) {
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css"
     />
-    <link rel="stylesheet" href="/assets/css/main.min.css?1.0.1" />
+    <link rel="stylesheet" href="/assets/css/main.min.css?1.0.2" />
     <link rel="stylesheet" href="/assets/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" />
     <link rel="stylesheet" href="/assets/css/dev-styles.css" />

--- a/front/app/src/pages/tournaments/[slug].astro
+++ b/front/app/src/pages/tournaments/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import Accordion from "~/components/accordion.astro";
 import GroupTable from "~/components/groupTables.astro";
+import GroupsQ from "~/components/leagueGroupsQ.astro";
 const { slug } = Astro.params;
 
 const tournament = await fetch(
@@ -26,7 +27,7 @@ const tournament = await fetch(
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css"
     />
-    <link rel="stylesheet" href="/assets/css/main.min.css?1.0.1" />
+    <link rel="stylesheet" href="/assets/css/main.min.css?1.0.2" />
     <link rel="stylesheet" href="/assets/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" />
     <link rel="stylesheet" href="/assets/css/dev-styles.css" />
@@ -98,6 +99,18 @@ const tournament = await fetch(
     <section class="d-ranking d-tournaments-calendar bg-img-race">
       <div class="col-12 container b-ranking-race b-top">
         <div class="row">
+          {
+            (tournament.tournament.type = "liga" &&
+              tournament.tournament.param_q_per_group != "2" && (
+                <div class="d-info-results d-info">
+                  <div class="col-12 b-accordion" id="resultados_torneo_data">
+                    <div class="accordion" id="accordionPanelsStayOpen-2">
+                      <GroupsQ tID={slug} />
+                    </div>
+                  </div>
+                </div>
+              ))
+          }
           <GroupTable groupID="A" tID={slug} />
           <GroupTable groupID="B" tID={slug} />
           <GroupTable groupID="C" tID={slug} />
@@ -108,31 +121,31 @@ const tournament = await fetch(
         </div>
       </div>
     </section>
-    <!-- JS -->
-    <script is:inline src="assets/js/jquery-3.6.1.min.js"></script>
-    <script is:inline src="https://code.jquery.com/jquery-latest.js"></script>
-    <script
-      is:inline
-      src="https://canvasjs.com/assets/script/jquery.canvasjs.min.js"></script>
-    <script
-      is:inline
-      src="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.js"></script>
-
-    <script is:inline src="/assets/js/aos.min.js"></script>
-    <script is:inline src="/assets/js/lazyload.js"></script>
-    <script is:inline src="/assets/js/bootstrap.min.js"></script>
-    <script is:inline src="/assets/js/custom.js"></script>
-
-    <script is:inline>
-      AOS.init({
-        once: true,
-        duration: 1500,
-        delay: 100,
-        disable: "mobile",
-      });
-      $(window).scroll(function () {
-        AOS.refresh();
-      });
-    </script>
   </body>
+  <!-- JS -->
+  <script is:inline src="assets/js/jquery-3.6.1.min.js"></script>
+  <script is:inline src="https://code.jquery.com/jquery-latest.js"></script>
+  <script
+    is:inline
+    src="https://canvasjs.com/assets/script/jquery.canvasjs.min.js"></script>
+  <script
+    is:inline
+    src="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.js"></script>
+
+  <script is:inline src="/assets/js/aos.min.js"></script>
+  <script is:inline src="/assets/js/lazyload.js"></script>
+  <script is:inline src="/assets/js/bootstrap.min.js"></script>
+  <script is:inline src="/assets/js/custom.js"></script>
+
+  <script is:inline>
+    AOS.init({
+      once: true,
+      duration: 1500,
+      delay: 100,
+      disable: "mobile",
+    });
+    $(window).scroll(function () {
+      AOS.refresh();
+    });
+  </script>
 </html>

--- a/front/app/src/pages/tournaments/[tid]/[gid].astro
+++ b/front/app/src/pages/tournaments/[tid]/[gid].astro
@@ -33,7 +33,7 @@ const tournament = await fetch(
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css"
     />
-    <link rel="stylesheet" href="/assets/css/main.min.css?1.0.1" />
+    <link rel="stylesheet" href="/assets/css/main.min.css?1.0.2" />
     <link rel="stylesheet" href="/assets/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" />
     <link rel="stylesheet" href="/assets/css/dev-styles.css" />


### PR DESCRIPTION
* Updated `main.min.css` with new version 1.0.2
* Added `leagueGroupsQ.astro` component to display league group rankings
* Updated `[slug].astro` and `[tid]/[gid].astro` pages to include new component for certain tournament types
* Made adjustments to `main.min.css` to accommodate new component layout

Note: The changes only affect tournaments with a "liga" type and a specific "param\_q\_per\_group" value.