### PR TITLE
 "Update leagueGroupsQ component, remove inline style from siteLayout…

### DIFF
--- a/front/app/src/components/leagueGroupsQ.astro
+++ b/front/app/src/components/leagueGroupsQ.astro
@@ -55,27 +55,27 @@ const globalQ = await fetch(
                       <p class="group_couple mb-4">{item.couple_names}</p>
                       <div class="row d-flex justify-content-center">
                         <div class="col-2 text-center">
-                          <p>&nbsp;</p>
+                          <p>P</p>
                           <p class="points">{index + 1}</p>
                         </div>
                         <div class="col-2 text-center">
-                          <p>Grupo</p>
+                          <p>&nbsp;</p>
                           <p class="points">{item.group_id + item.id}</p>
                         </div>
                         <div class="col-2 text-center">
-                          <p>Sets</p>
+                          <p>S</p>
                           <p class="points">{item.sets_total}</p>
                         </div>
                         <div class="col-2 text-center">
-                          <p>Games</p>
+                          <p>G</p>
                           <p class="points">{item.total_games}</p>
                         </div>
                         <div class="col-2 text-center">
-                          <p>Games+</p>
+                          <p>G+</p>
                           <p class="points">{item.games_positive}</p>
                         </div>
                         <div class="col-2 text-center">
-                          <p>Ganados</p>
+                          <p>PG</p>
                           <p class="points">{item.wins}</p>
                         </div>
                       </div>

--- a/front/app/src/layouts/siteLayout.astro
+++ b/front/app/src/layouts/siteLayout.astro
@@ -44,12 +44,7 @@ const { title, image, url } = Astro.props;
     <meta name="twitter:title" content={title} />
     <meta name="twitter:text:description" content={title} />
     <meta name="twitter:image:src" content={image} />
-    <style is:inline>
-      .row {
-        margin-left: 0px;
-        margin-right: 0px;
-      }
-    </style>
+
     <ViewTransitions />
   </head>
 

--- a/front/app/src/pages/index.astro
+++ b/front/app/src/pages/index.astro
@@ -24,7 +24,7 @@ function getDateMonth(dateStr: string) {
 
 function getDateDay(dateStr: string) {
   const date = new Date(dateStr);
-  const formatter = new Intl.DateTimeFormat("en-US", dateOptionsDay);
+  const formatter = new Intl.DateTimeFormat("es-ES", dateOptionsDay);
   return formatter.format(date);
 }
 ---
@@ -63,11 +63,9 @@ function getDateDay(dateStr: string) {
                         </div>
                       </div>
                       <div class="col-md-8 col-lg-9 b-name">
-                        <div class="row">
-                          <div class="col-6">
+                        <div>
+                          <div class="d-flex justify-content-between align-items-center">
                             <p>{tournament.name}</p>
-                          </div>
-                          <div class="col-6 text-end">
                             <picture>
                               <img
                                 decoding="async"


### PR DESCRIPTION
…, and update date formatting in index page"

This commit includes the following changes:

1. In the `leagueGroupsQ` component, update the labels for the points columns to display as "P", "G", "S", "G+", and "PG".
2. Remove the inline style for the `.row` class from the `siteLayout` component.
3. In the `index` page, update the date formatting for the day to use the "es-ES" locale instead of "en-US".