### PR TITLE
 Accordion button state change in 'accordion.astro' and 'leagueGroups…

### DIFF
--- a/front/app/src/components/accordion.astro
+++ b/front/app/src/components/accordion.astro
@@ -54,7 +54,7 @@ switch (round) {
       <div class="accordion-item aos-init aos-animate" data-aos="fade-up">
         <h2 class="accordion-header" id={`ppanelsStayOpen-heading-0-${round}`}>
           <button
-            class={`accordion-button ${round == "1" ? "collapsed" : ""}`}
+            class={`accordion-button ${round == "1" ? "" : "collapsed"}`}
             type="button"
             data-bs-toggle="collapse"
             data-bs-target={`#ppanelsStayOpen-collapse-0-${round}`}

--- a/front/app/src/components/leagueGroupsQ.astro
+++ b/front/app/src/components/leagueGroupsQ.astro
@@ -15,7 +15,7 @@ const globalQ = await fetch(
     <div class="accordion-item aos-init aos-animate" data-aos="fade-up">
       <h2 class="accordion-header" id={`ppanelsStayOpen-heading-0-${round}`}>
         <button
-          class={`accordion-button`}
+          class={`accordion-button collapsed`}
           type="button"
           data-bs-toggle="collapse"
           data-bs-target={`#ppanelsStayOpen-collapse-0-${round}`}


### PR DESCRIPTION
…Q.astro' components

In 'accordion.astro', the 'collapsed' class is added to the accordion button when the round is not equal to 1. In 'leagueGroupsQ.astro', the 'collapsed' class is added to the accordion button by default.