### PR TITLE
 "Update group result validation to consider individual set wins"

### DIFF
--- a/back/app/app/lib/tournamentGroupResultActions.ts
+++ b/back/app/app/lib/tournamentGroupResultActions.ts
@@ -148,8 +148,11 @@ export async function updateGroupResult(
   const group_id = formData.get("group_id")?.toString() || "";
 
   if (
-    Number(set_1_c1) + Number(set_2_c1) + Number(set_3_c1) >
-    Number(set_1_c2) + Number(set_2_c2) + Number(set_3_c2)
+    (Number(set_1_c1) > Number(set_1_c2) &&
+      Number(set_2_c1) > Number(set_2_c2)) ||
+    (Number(set_1_c1) > Number(set_1_c2) &&
+      Number(set_3_c1) > Number(set_3_c2)) ||
+    (Number(set_2_c1) > Number(set_2_c2) && Number(set_3_c1) > Number(set_3_c2))
   ) {
     winner = "couple_1";
   } else {


### PR DESCRIPTION
This commit updates the validation logic in the `updateGroupResult` function to consider individual set wins when determining the winner of a match. Previously, the validation compared the total points scored by each couple; now, it checks if one couple has won more individual sets than the other.