### PR TITLE
Update site and page URLs to use new domain; update AOS initialization

### DIFF
--- a/front/app/public/assets/css/dev-styles.css
+++ b/front/app/public/assets/css/dev-styles.css
@@ -79,3 +79,13 @@ body {
   line-height: 14px;
   font-size: 14px;
 }
+
+footer {
+  position: relative;
+  background-color: #021060;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  padding-top: 44px;
+  padding-bottom: 44px;
+  margin-top: 0px;
+}

--- a/front/app/src/layouts/siteLayout.astro
+++ b/front/app/src/layouts/siteLayout.astro
@@ -60,21 +60,13 @@ const { title, image, url } = Astro.props;
       is:inline
       src="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.js"></script>
 
-    <script is:inline src="/assets/js/aos.min.js"></script>
+    <script is:inline src="https://unpkg.com/aos@next/dist/aos.js"></script>
     <script is:inline src="/assets/js/lazyload.js"></script>
     <script is:inline src="/assets/js/bootstrap.min.js"></script>
     <script is:inline src="/assets/js/custom.js"></script>
 
     <script is:inline>
-      AOS.init({
-        once: true,
-        duration: 1500,
-        delay: 100,
-        disable: "mobile",
-      });
-      $(window).scroll(function () {
-        AOS.refresh();
-      });
+      AOS.init();
     </script>
   </body>
 </html>

--- a/front/app/src/pages/index.astro
+++ b/front/app/src/pages/index.astro
@@ -32,7 +32,7 @@ function getDateDay(dateStr: string) {
 <SiteLayout
   title="iPadel"
   image="/favicon.svg"
-  url={`https://torneos-manager.vercel.app`}
+  url={`https://torneos-manager-f.vercel.app`}
 >
   <!-- Tournaments -->
   <section class="d-tournaments-calendar">

--- a/front/app/src/pages/tournaments/[slug].astro
+++ b/front/app/src/pages/tournaments/[slug].astro
@@ -16,7 +16,7 @@ const tournament = await fetch(
 <SiteLayout
   title={tournament.tournament.name}
   image={tournament.tournament.image}
-  url={`https://torneos-manager.vercel.app/trounaments/${slug}`}
+  url={`https://torneos-manager-f.vercel.app/trounaments/${slug}`}
 >
   <!-- Title -->
   <section class="d-menu-tournament">

--- a/front/app/src/pages/tournaments/[tid]/[gid].astro
+++ b/front/app/src/pages/tournaments/[tid]/[gid].astro
@@ -23,7 +23,7 @@ const tournament = await fetch(
 <SiteLayout
   title={`${tournament.tournament.name} - Partidos Grupo ${gid}`}
   image={tournament.tournament.image}
-  url={`https://torneos-manager.vercel.app/trounaments/${tournament.tournament.id}`}
+  url={`https://torneos-manager-f.vercel.app/trounaments/${tournament.tournament.id}`}
 >
   <!-- Title -->
   <section class="d-menu-tournament">


### PR DESCRIPTION
* Changes the base URL for the site and individual pages from `https://torneos-manager.vercel.app` to `https://torneos